### PR TITLE
Fixed checkbox printing preferences handling

### DIFF
--- a/layout.js
+++ b/layout.js
@@ -271,16 +271,15 @@ function dpyChecklist(clobj)
 	var arr = clobj.checkItems;
 	var cnt = 0;
 	for (var i=0; i<arr.length; i++){
-
 		var obj = arr[i];
-
+		// Handle preferences for checkbox state
+		if(mode == 'none') continue;
+		if(mode == 'checked-only' && obj.state == 'incomplete') continue;
+		if(mode == 'unchecked-only' && obj.state != 'incomplete') continue;
+		
 		var ckmk = '[x]';
 		if (obj.state == 'incomplete'){ 
-			if (mode == 'checked-only') continue;
 			ckmk = '[&nbsp;]'
-		}
-		else {
-			if (mode == 'checked-only') ckmk = '___ ';
 		}
 
 		htm.push('<br>&nbsp;&nbsp;<tt>', ckmk, '</tt> ', obj.name);

--- a/layout.js
+++ b/layout.js
@@ -258,7 +258,7 @@ console.log('xref.',j, arr[j], cardHtm[arr[j]]);
 function dpyChecklist(clobj)
 {
 //console.log(clobj);
-
+	var showMembers = prefVal.showChecklistItemMembers;
 	var htm = [];
 	htm.push('<p class=checklist>',clobj.name);
 
@@ -281,8 +281,15 @@ function dpyChecklist(clobj)
 		if (obj.state == 'incomplete'){ 
 			ckmk = '[&nbsp;]'
 		}
+		var objMember = obj.idMember;
+        var objMemberName = '';
+        if (showMembers != 'do-not-show' && objMember != null) {
+            var who = DB.whoLookup[objMember];
+            if (showMembers == 'show-initials') objMemberName='(' + who.initials + ')';
+            else objMemberName = '(' + who.fullName + ')';
+        }
 
-		htm.push('<br>&nbsp;&nbsp;<tt>', ckmk, '</tt> ', obj.name);
+		htm.push('<br>&nbsp;&nbsp;<tt>', ckmk, '</tt> ', objMemberName, ' ', obj.name);
 		++cnt;
 	}
 	if (cnt == 0) return '';

--- a/pref.js
+++ b/pref.js
@@ -127,6 +127,15 @@ var prefSpec = [
 			'checked-only'],
 		dflt: 'all' },
 
+  { key: 'showChecklistItemMembers',
+                name: 'Show Checklist Item Members',
+                type: 'pulldown',
+                options: [
+                        'do-not-show',
+                        'show-initials',
+                        'show-fullnames'
+                        ],
+                dflt: 'do-not-show' },
 
   { type: 'fieldset', name: 'Comments' }, 
 


### PR DESCRIPTION
This method used to add an HTML element for every checkbox, regardless of printing preferences. This commit first compares checkbox state to the print preferences, skipping checkboxes elements entirely where appropriate